### PR TITLE
Fix normalization for vectors with length 0

### DIFF
--- a/dist/vec.module.js
+++ b/dist/vec.module.js
@@ -109,7 +109,7 @@ var vLerp = curry(function (v1, v2, t) {
 // vNorm :: Vector -> Vector
 var vNorm = function vNorm(v) {
   var mag = vMag(v);
-  return [v[0] / mag, v[1] / mag];
+  return mag === 0 ? v : [v[0] / mag, v[1] / mag];
 };
 
 // mId :: Matrix

--- a/dist/vec.window.js
+++ b/dist/vec.window.js
@@ -106,7 +106,7 @@ var vLerp = curry(function (v1, v2, t) {
 // vNorm :: Vector -> Vector
 var vNorm = function vNorm(v) {
   var mag = vMag(v);
-  return [v[0] / mag, v[1] / mag];
+  return mag === 0 ? v : [v[0] / mag, v[1] / mag];
 };
 
 // mId :: Matrix

--- a/src/vec.main.js
+++ b/src/vec.main.js
@@ -64,7 +64,7 @@ const vLerp = curry((v1, v2, t) => vTowards(t, v1, v2));
 // vNorm :: Vector -> Vector
 const vNorm = (v) => {
   const mag = vMag(v);
-  return [
+  return mag === 0 ? v : [
     v[0] / mag,
     v[1] / mag
   ];

--- a/tests/vec.test.js
+++ b/tests/vec.test.js
@@ -63,6 +63,11 @@ describe('Vec-la', function() {
     expect(vec.norm(v1)).to.deep.equal([3 / 5, 4 / 5]);
   });
 
+  it('should be able to normalize a zero vector', () => {
+    const v1 = [0, 0];
+    expect(vec.norm(v1)).to.deep.equal(v1);
+  });
+
   it('should scale a vector', () => {
     const v1 = [3, 4];
     const sc = 10;


### PR DESCRIPTION
I ran into a problem where normalizing a zero vector would return me `[NaN, NaN]`, since it would try to divide the vector elements by zero. Now that case will be handled :)